### PR TITLE
[feat] 대시보드 반응률 집계기준 변경

### DIFF
--- a/src/dashboard/infra/dashboard_sqlalchemy_repository.py
+++ b/src/dashboard/infra/dashboard_sqlalchemy_repository.py
@@ -269,10 +269,10 @@ class DashboardSqlAlchemy:
                 campaign_stats_data.c.t_response_cust_count.label("response_cust_count"),
                 (
                     case(
-                        (campaign_stats_data.c.t_response_cust_count == 0, 0),
+                        (dash_daily_send_info.c.tot_success_count == 0, 0),
                         else_=(
                             campaign_stats_data.c.t_response_cust_count
-                            / dash_daily_send_info.c.tot_recipient_count
+                            / dash_daily_send_info.c.tot_success_count
                         ),
                     )
                 ).label("response_rate"),
@@ -289,10 +289,10 @@ class DashboardSqlAlchemy:
                 campaign_stats_data.c.e_response_cust_count,
                 (
                     case(
-                        (campaign_stats_data.c.e_response_cust_count == 0, 0),
+                        (dash_daily_send_info.c.tot_success_count == 0, 0),
                         else_=(
                             campaign_stats_data.c.e_response_cust_count
-                            / dash_daily_send_info.c.tot_recipient_count
+                            / dash_daily_send_info.c.tot_success_count
                         ),
                     )
                 ).label("e_response_rate"),
@@ -595,10 +595,10 @@ class DashboardSqlAlchemy:
             ),
             func.cast(
                 case(
-                    (campaign_group_stats.c.t_response_cust_count == 0, 0),
+                    (dash_daily_send_info.c.tot_success_count == 0, 0),
                     else_=(
                         campaign_group_stats.c.t_response_cust_count
-                        / dash_daily_send_info.c.tot_recipient_count
+                        / dash_daily_send_info.c.tot_success_count
                     ),
                 ),
                 Float,
@@ -613,10 +613,10 @@ class DashboardSqlAlchemy:
             (campaign_group_stats.c.e_response_cust_count).label("e_response_cust_count"),
             func.cast(
                 case(
-                    (campaign_group_stats.c.e_response_cust_count == 0, 0),
+                    (dash_daily_send_info.c.tot_success_count == 0, 0),
                     else_=(
                         campaign_group_stats.c.e_response_cust_count
-                        / dash_daily_send_info.c.tot_recipient_count
+                        / dash_daily_send_info.c.tot_success_count
                     ),
                 ),
                 Float,
@@ -755,9 +755,17 @@ class DashboardSqlAlchemy:
             dash_daily_send_info.c.audience_id,
             dash_daily_send_info.c.audience_name,
             dash_daily_send_info.c.tot_recipient_count.label("recipient_count"),
+            dash_daily_send_info.c.tot_success_count.label("sent_cust_count"),
             audience_stats.c.t_response_cust_count.label("response_cust_count"),
-            (
-                audience_stats.c.t_response_cust_count / dash_daily_send_info.c.tot_recipient_count
+            func.cast(
+                case(
+                    (dash_daily_send_info.c.tot_success_count == 0, 0),
+                    else_=(
+                        audience_stats.c.t_response_cust_count
+                        / dash_daily_send_info.c.tot_success_count
+                    ),
+                ),
+                Float,
             ).label("response_rate"),
             audience_stats.c.t_response_revenue.label("response_revenue"),
             (audience_stats.c.t_response_revenue / dash_daily_send_info.c.tot_send_cost).label(

--- a/src/dashboard/infra/dto/response/campaign_audience_stats_response.py
+++ b/src/dashboard/infra/dto/response/campaign_audience_stats_response.py
@@ -13,6 +13,7 @@ class CampaignAudienceStatsResponse(BaseModel):
     audience_id: str
     audience_name: str
     recipient_count: int | None = None
+    sent_cust_count: int | None = None
     response_cust_count: int | None = None
     response_rate: float | None = None
     response_revenue: int | None = None

--- a/src/dashboard/service/get_campaign_group_stats_service.py
+++ b/src/dashboard/service/get_campaign_group_stats_service.py
@@ -10,8 +10,6 @@ class GetCampaignGroupStatsService:
         self.code_dict = {
             "audience_name": "타겟 오디언스",
             "group_sort_num": "그룹",
-            "cust_grade1_nm": "멤버십 등급",
-            "age_group_10": "연령대",
             "cv_lv2": "CV",
         }
 

--- a/src/dashboard/service/get_campaign_stats_service.py
+++ b/src/dashboard/service/get_campaign_stats_service.py
@@ -41,13 +41,25 @@ class GetCampaignStatsService:
 
         if len(campaign_stats_df) > 0:
             campaign_summary_stats_df.replace({np.nan: None}, inplace=True)
-            campaign_summary_stats_df["response_rate"] = (
-                campaign_summary_stats_df.response_cust_count
-                / campaign_summary_stats_df.recipient_count
+            campaign_summary_stats_df["response_rate"] = campaign_summary_stats_df[
+                ["sent_cust_count", "response_cust_count"]
+            ].apply(
+                lambda x: (
+                    x["response_cust_count"] / x["sent_cust_count"]
+                    if x["sent_cust_count"] > 0
+                    else 0
+                ),
+                axis=1,
             )
-            campaign_summary_stats_df["e_response_rate"] = (
-                campaign_summary_stats_df.e_response_cust_count
-                / campaign_summary_stats_df.recipient_count
+            campaign_summary_stats_df["e_response_rate"] = campaign_summary_stats_df[
+                ["sent_cust_count", "e_response_cust_count"]
+            ].apply(
+                lambda x: (
+                    x["e_response_cust_count"] / x["sent_cust_count"]
+                    if x["sent_cust_count"] > 0
+                    else 0
+                ),
+                axis=1,
             )
 
             campaign_summary_stats_df.response_unit_price = campaign_summary_stats_df[


### PR DESCRIPTION
- 대시보드 반응률 집계기준, 타겟고객 > 발송성공 고객
- 그룹분석 옵션에서 멤버십, 연령대 삭제