### PR TITLE
Feature/ac 32

### DIFF
--- a/src/auth/routes/ga_router.py
+++ b/src/auth/routes/ga_router.py
@@ -36,10 +36,10 @@ def get_ga_script(
 
 @ga_router.patch("/status", status_code=status.HTTP_204_NO_CONTENT)
 @inject
-def change_ga_script_status(
+async def change_ga_script_status(
     to_status: GAScriptStatus,
     ga_service: BaseGAIntegrationService = Depends(Provide[Container.ga_service]),
     user=Depends(get_permission_checker(required_permissions=[])),
     db: Session = Depends(get_db),
 ):
-    ga_service.update_status(user, to_status.value, db=db)
+    await ga_service.update_status(user, to_status.value, db=db)

--- a/src/auth/routes/port/base_ga_service.py
+++ b/src/auth/routes/port/base_ga_service.py
@@ -23,5 +23,5 @@ class BaseGAIntegrationService(ABC):
 
     @transactional
     @abstractmethod
-    def update_status(self, user: User, to_status: str, db: Session):
+    async def update_status(self, user: User, to_status: str, db: Session):
         pass


### PR DESCRIPTION
고객사에서 GA 연동 실행하기를 누른 경우, 트리거가 실행되도록 변경

기존
- GA 스크립트 생성 후, 다음날 오전 11시에 트리거
- 하지만, 고객사에서 GA 스크립트를 카페24에 등록하지 않은 경우 빅쿼리 테이블이 생성되지 않으므로 DAG가 정상적으로 동작하지 않음